### PR TITLE
Discard spot instances from lists

### DIFF
--- a/lib/aws_common.rb
+++ b/lib/aws_common.rb
@@ -81,7 +81,7 @@ module AwsCommon
               platform = instance.platform.blank? ? "Linux/UNIX" : "Windows"
               platform = PLATFORMS[amis[instance.image_id]] if !amis[instance.image_id].nil? && !PLATFORMS[amis[instance.image_id]].nil?
 
-              instances[instance.id] = {type: instance.instance_type, az: instance.placement.availability_zone, tenancy: instance.placement.tenancy, platform: platform, account_id: account_id[0], vpc: instance.vpc_id.blank? ? "EC2 Classic" : "VPC", ami: instance.image_id} if instance.state.name == 'running'
+              instances[instance.id] = {type: instance.instance_type, az: instance.placement.availability_zone, tenancy: instance.placement.tenancy, platform: platform, account_id: account_id[0], vpc: instance.vpc_id.blank? ? "EC2 Classic" : "VPC", ami: instance.image_id} if instance.state.name == 'running' and instance.instance_lifecycle != 'spot'
             end
           end
         end


### PR DESCRIPTION
This PR modifies the AwsCommon module so that it does not consider instances with spot lifecycle in their listings.

Reserved Instances are not applied in the spot type instance.